### PR TITLE
Improve the detection of entry points in x86_64

### DIFF
--- a/macaw-loader/macaw-loader.cabal
+++ b/macaw-loader/macaw-loader.cabal
@@ -29,6 +29,7 @@ cabal-version:       >=1.10
 
 library
   exposed-modules: Data.Macaw.BinaryLoader
+                   Data.Macaw.BinaryLoader.ELF
   build-depends:       base >=4.9 && <5
                      , bytestring
                      , elf-edit >= 0.39

--- a/macaw-loader/src/Data/Macaw/BinaryLoader/ELF.hs
+++ b/macaw-loader/src/Data/Macaw/BinaryLoader/ELF.hs
@@ -1,0 +1,26 @@
+module Data.Macaw.BinaryLoader.ELF (
+  resolveAbsoluteAddress
+  ) where
+
+import qualified Data.Macaw.Memory as MM
+
+-- | Resolve a 'MM.MemWord', interpreted as an absolute address, into a 'MM.MemSegmentOff'
+--
+-- This is useful for resolving the entry point of a binary into a macaw
+-- address.  At the level of an ELF file (or other executable container),
+-- addresses are given as "absolute" addresses.  This is a bit of a convenient
+-- fiction as the real address cannot be known until load time when the OS (or
+-- bootleader) maps the executable into memory at some offset.  In some sense,
+-- all of the addresses given in the executable container are *offsets from an abstract base*.
+--
+-- Macaw loads dynamically linked and statically linked binaries slightly
+-- differently, where addresses in the statically linked case are all "absolute"
+-- with region number 0.  Dynamically linked executables have a different region
+-- number.  This function searches for the segment containing the ostensibly
+-- absolute address and converts it into a 'MM.MemSegmentOff'.
+resolveAbsoluteAddress
+  :: (MM.MemWidth w)
+  => MM.Memory w
+  -> MM.MemWord w
+  -> Maybe (MM.MemSegmentOff w)
+resolveAbsoluteAddress mem addr = MM.resolveAbsoluteAddr mem addr


### PR DESCRIPTION
This new approach correctly handles entry points for dynamically linked
binaries, where the previous approach failed due to the use of `asSegmentOff`.
The `resolveAbsoluteAddress` function does the correct resolution to look up the
actual segment.