### PR TITLE
Add the original binary to the `LoadedBinary` type

### DIFF
--- a/macaw-loader-aarch32/src/Data/Macaw/BinaryLoader/AArch32.hs
+++ b/macaw-loader-aarch32/src/Data/Macaw/BinaryLoader/AArch32.hs
@@ -83,6 +83,7 @@ loadAArch32Binary lopts e =
                                                }
                               , MBL.loadDiagnostics = warnings
                               , MBL.binaryRepr = MBL.Elf32Repr
+                              , MBL.originalBinary = e
                               }
 
 indexSymbols :: [EL.MemSymbol 32] -> Map.Map (MM.MemAddr 32) BS.ByteString

--- a/macaw-loader-ppc/src/Data/Macaw/BinaryLoader/PPC.hs
+++ b/macaw-loader-ppc/src/Data/Macaw/BinaryLoader/PPC.hs
@@ -138,6 +138,7 @@ loadPPCBinary binRep lopts e = do
                                               }
                                  , BL.loadDiagnostics = warnings
                                  , BL.binaryRepr = binRep
+                                 , BL.originalBinary = e
                                  }
 
 indexSymbols :: (Foldable t)

--- a/macaw-loader-x86/src/Data/Macaw/BinaryLoader/X86.hs
+++ b/macaw-loader-x86/src/Data/Macaw/BinaryLoader/X86.hs
@@ -83,6 +83,7 @@ loadX86Binary lopts e = do
                                           }
                              , BL.loadDiagnostics = warnings
                              , BL.binaryRepr = BL.Elf64Repr
+                             , BL.originalBinary = e
                              }
 
 indexSymbols :: [EL.MemSymbol 64] -> Map.Map (MM.MemAddr 64) BS.ByteString

--- a/macaw-loader/src/Data/Macaw/BinaryLoader.hs
+++ b/macaw-loader/src/Data/Macaw/BinaryLoader.hs
@@ -39,6 +39,7 @@ data LoadedBinary arch binFmt =
                , binaryFormatData :: BinaryFormatData arch binFmt
                , loadDiagnostics :: [Diagnostic arch binFmt]
                , binaryRepr :: BinaryRepr binFmt
+               , originalBinary :: binFmt
                }
 
 -- | A class for architecture and binary container independent binary loading


### PR DESCRIPTION
Some of the backends made it available in the arch-specific section, but there
is no reason to not just include it at the top level. Clients would need to fix
the `binFmt` parameter to access it.