### PR TITLE
Make the loader interface more robust

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc-ver: ["8.6.5", "8.8.4", "8.10.2"]
+        ghc-ver: ["8.6.5", "8.8.4", "8.10.5"]
       # complete all jobs
       fail-fast: false
     name: macaw-loader - GHC v${{ matrix.ghc-ver }} - ubuntu-latest
@@ -21,9 +21,9 @@ jobs:
         cp cabal.project.dist                                  cabal.project
     - name: Get GHC
       run: |
-        sudo apt-get install --no-install-recommends -y cabal-install-3.2 ghc-${{ matrix.ghc-ver }}
-        echo "/opt/cabal/bin" >> $GITHUB_PATH
-        echo "/opt/ghc/${{ matrix.ghc-ver }}/bin" >> $GITHUB_PATH
+        ghcup install ghc ${{ matrix.ghc-ver }}
+        ghcup install cabal 3.4.0.0
+        ghcup set ghc ${{ matrix.ghc-ver }}
     - name: Cache
       uses: actions/cache@v1
       with:

--- a/macaw-loader-aarch32/src/Data/Macaw/BinaryLoader/AArch32.hs
+++ b/macaw-loader-aarch32/src/Data/Macaw/BinaryLoader/AArch32.hs
@@ -16,6 +16,7 @@ import qualified Data.ElfEdit as EE
 import qualified Data.Foldable as F
 import qualified Data.List.NonEmpty as DLN
 import qualified Data.Macaw.BinaryLoader as MBL
+import qualified Data.Macaw.BinaryLoader.ELF as BLE
 import qualified Data.Macaw.Memory as MM
 import qualified Data.Macaw.Memory.ElfLoader as EL
 import qualified Data.Macaw.Memory.LoadCommon as LC
@@ -51,15 +52,15 @@ aarch32EntryPoints :: (X.MonadThrow m)
                    => MBL.LoadedBinary MA.ARM (EE.ElfHeaderInfo 32)
                    -> m (DLN.NonEmpty (MM.MemSegmentOff 32))
 aarch32EntryPoints loadedBinary =
-  case MM.asSegmentOff mem addr of
+  case BLE.resolveAbsoluteAddress mem addr of
     Nothing -> X.throwM (InvalidEntryPoint addr)
     Just entryPoint ->
-      return (entryPoint DLN.:| mapMaybe (MM.asSegmentOff mem) symbols)
+      return (entryPoint DLN.:| mapMaybe (BLE.resolveAbsoluteAddress mem) symbols)
   where
     mem = MBL.memoryImage loadedBinary
-    addr = MM.absoluteAddr (MM.memWord (fromIntegral (EE.headerEntry (EE.header (elf (MBL.binaryFormatData loadedBinary))))))
+    addr = MM.memWord (fromIntegral (EE.headerEntry (EE.header (elf (MBL.binaryFormatData loadedBinary)))))
     elfData = elf (MBL.binaryFormatData loadedBinary)
-    symbols = [ MM.absoluteAddr (MM.memWord (fromIntegral (EE.steValue entry)))
+    symbols = [ MM.memWord (fromIntegral (EE.steValue entry))
               | Just (Right st) <- [EE.decodeHeaderSymtab elfData]
               , entry <- F.toList (EE.symtabEntries st)
               , EE.steType entry == EE.STT_FUNC
@@ -93,7 +94,7 @@ indexSymbols = F.foldl' doIndex Map.empty
       Map.insert (MM.segoffAddr (EL.memSymbolStart memSym)) (EL.memSymbolName memSym) m
 
 data AArch32LoadException = AArch32ElfLoadError String
-                          | InvalidEntryPoint (MM.MemAddr 32)
+                          | InvalidEntryPoint (MM.MemWord 32)
                           | MissingSymbolFor (MM.MemAddr 32)
 
 deriving instance Show AArch32LoadException

--- a/macaw-loader/src/Data/Macaw/BinaryLoader/ELF.hs
+++ b/macaw-loader/src/Data/Macaw/BinaryLoader/ELF.hs
@@ -2,6 +2,8 @@ module Data.Macaw.BinaryLoader.ELF (
   resolveAbsoluteAddress
   ) where
 
+import           Data.Maybe ( listToMaybe )
+
 import qualified Data.Macaw.Memory as MM
 
 -- | Resolve a 'MM.MemWord', interpreted as an absolute address, into a 'MM.MemSegmentOff'
@@ -23,4 +25,9 @@ resolveAbsoluteAddress
   => MM.Memory w
   -> MM.MemWord w
   -> Maybe (MM.MemSegmentOff w)
-resolveAbsoluteAddress mem addr = MM.resolveAbsoluteAddr mem addr
+resolveAbsoluteAddress mem addr =
+  listToMaybe [ segOff
+              | seg <- MM.memSegments mem
+              , let region = MM.segmentBase seg
+              , Just segOff <- return (MM.resolveRegionOff mem region addr)
+              ]


### PR DESCRIPTION
This addresses challenges when loading PIC binaries, which are sometimes just
shared libraries. Macaw loads shared libraries into a non-0 region, so we have
to search for which region an "absolute" address actually belongs to. The ELF
helper now takes this approach, and the AArch32 frontend uses it.