### PR TITLE
Take load offset into account in `entryPoints` implementations

### DIFF
--- a/macaw-loader/src/Data/Macaw/BinaryLoader.hs
+++ b/macaw-loader/src/Data/Macaw/BinaryLoader.hs
@@ -40,6 +40,7 @@ data LoadedBinary arch binFmt =
                , loadDiagnostics :: [Diagnostic arch binFmt]
                , binaryRepr :: BinaryRepr binFmt
                , originalBinary :: binFmt
+               , loadOptions :: LC.LoadOptions
                }
 
 -- | A class for architecture and binary container independent binary loading


### PR DESCRIPTION
This change stores load options with the loaded binary and uses those
options to properly calculate entry point addresses such that they
include the offset the binary was loaded at.